### PR TITLE
Remove build_function_request_url default param

### DIFF
--- a/lib/class-anvato-library.php
+++ b/lib/class-anvato-library.php
@@ -202,7 +202,7 @@ class Anvato_Library {
 	 *     function because the same timestamp is needed more than once.
 	 * @return string The URL after formatting with sprintf().
 	 */
-	private function build_request_url( $params = array(), $time ) {
+	private function build_request_url( $params, $time ) {
 		return sprintf(
 			$this->api_request_url,
 			esc_url( $this->general_settings['mcp']['url'] ), $time,


### PR DESCRIPTION
This PR is meant to resolve #1.

Given the usage in the plugin, removing the default parameter from `$params` should have no negative effect.