### PR TITLE
Add some remediations for issues introduces by PHP 8

### DIFF
--- a/lib/class-anvato-library.php
+++ b/lib/class-anvato-library.php
@@ -319,10 +319,12 @@ class Anvato_Library {
 
 		$api_method = $this->api_methods[$args['type']];
 
-		foreach ( $this->general_settings['owners'] as $ow_item ) {
-			if ( $args['station'] === $ow_item['id'] ) {
-				$this->selected_station = $ow_item;
-				break;
+		if ( isset( $this->general_settings['owners'] ) ) {
+			foreach ( $this->general_settings['owners'] as $ow_item ) {
+				if ( $args['station'] === $ow_item['id'] ) {
+					$this->selected_station = $ow_item;
+					break;
+				}
 			}
 		}
 

--- a/lib/shortcode.php
+++ b/lib/shortcode.php
@@ -18,12 +18,24 @@ function anvato_shortcode_get_parameters( $attr ) {
 	$analytics = Anvato_Settings()->get_options( Anvato_Settings::ANALYTICS_SETTINGS_KEY );
 	$monetization = Anvato_Settings()->get_options( Anvato_Settings::MONETIZATION_SETTINGS_KEY );
 
+	if ( ! isset( $player['width'] ) || ! isset( $player['width_type'] ) ) {
+		// If either is unset, this can't be a valid value so substitute one.
+		$width = '100%';
+	} else {
+		$width = $player['width'] . $player['width_type'];
+	}
+	if ( ! isset( $player['height'] ) || ! isset( $player['height_type'] ) ) {
+		// If either is unset, this can't be a valid value so substitute one.
+		$height = '100%';
+	} else {
+		$height = $player['height'] . $player['height_type'];
+	}
 	// Set the attributes which the shortcode can override
 	$json = shortcode_atts(
 		array(
 			'mcp' => $mcp['mcp']['id'] ?? '',
-			'width' => $player['width'] . $player['height_type'],
-			'height' => $player['height'] . $player['width_type'],
+			'width' => $width,
+			'height' => $height,
 			'video' => null,
 			'station'=>null,
 			'ext_id' => null,

--- a/lib/shortcode.php
+++ b/lib/shortcode.php
@@ -146,7 +146,7 @@ function anvato_shortcode_get_parameters( $attr ) {
 	unset($json['station']);
 	
 	//Special consideration for heartbeat analytics
-	$account_obj = json_decode($analytics['heartbeat_account_id']);
+	$account_obj = json_decode($analytics['heartbeat_account_id'] ?? '');
 	if(is_object($account_obj))
 	{
 		$json['plugins']['heartbeat']['account'] = $account_obj;


### PR DESCRIPTION
This should resolve the following errors:

- Warning: Undefined array key "heartbeat_account_id" in /var/www/wp-content/plugins/wp-anvato-plugin/lib/shortcode.php on line 149
- Warning: Trying to access array offset on value of type null in /var/www/wp-content/plugins/wp-anvato-plugin/lib/class-anvato-library.php on line 322
- Warning: foreach() argument must be of type array|object, null given in /var/www/wp-content/plugins/wp-anvato-plugin/lib/class-anvato-library.php on line 322
- Warning: Trying to access array offset on value of type null in /var/www/wp-content/plugins/wp-anvato-plugin/lib/class-anvato-library.php on line 322
Warning: foreach() argument must be of type array|object, null given in /var/www/wp-content/plugins/wp-anvato-plugin/lib/class-anvato-library.php on line 322

See relevant ticket: https://nexstardigital.atlassian.net/browse/WC-1716